### PR TITLE
Add basic wallet UI

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,10 +1,17 @@
 <html>
     <head>
-        <link rel="stylesheet" href="css/style.css">
+        <link rel="stylesheet" href="css/styles.css">
     </head>
     <body>
-        <div>
-            Hello EdenCoin
+        <div id="wallet">
+            <h1>Balance: <span id="balance"></span></h1>
+            <form id="send-form">
+                <input type="text" name="address" placeholder="Address">
+                <input type="number" name="amount" placeholder="Amount">
+                <button type="submit">Send</button>
+            </form>
+            <h2>History</h2>
+            <div id="history"></div>
         </div>
         <script src="js/script.js"></script>
     </body>

--- a/src/renderer/js/script.js
+++ b/src/renderer/js/script.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const balanceEl = document.getElementById('balance');
+  const historyEl = document.getElementById('history');
+  const form = document.getElementById('send-form');
+
+  let balance = 10000;
+  balanceEl.textContent = balance + ' EDN';
+
+  const transactions = [
+    { date: '2022-01-01', amount: 1000, description: 'Received from Alice' },
+    { date: '2022-01-05', amount: -500, description: 'Sent to Bob' },
+  ];
+
+  function renderHistory() {
+    historyEl.innerHTML = '';
+    transactions.forEach(tx => {
+      const row = document.createElement('div');
+      row.className = 'tx-row';
+      row.innerHTML = `<span class="tx-date">${tx.date}</span>
+        <span class="tx-amount ${tx.amount >= 0 ? 'positive' : 'negative'}">${tx.amount >= 0 ? '+' : ''}${tx.amount} EDN</span>
+        <span class="tx-desc">${tx.description}</span>`;
+      historyEl.appendChild(row);
+    });
+  }
+
+  renderHistory();
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const address = form.elements['address'].value.trim();
+    const amount = parseFloat(form.elements['amount'].value);
+    if (!address || isNaN(amount)) return;
+    transactions.unshift({
+      date: new Date().toLocaleDateString(),
+      amount: -amount,
+      description: `Sent to ${address}`
+    });
+    balance -= amount;
+    balanceEl.textContent = balance + ' EDN';
+    renderHistory();
+    form.reset();
+  });
+});

--- a/src/renderer/scss/main.scss
+++ b/src/renderer/scss/main.scss
@@ -1,0 +1,44 @@
+#wallet {
+  font-family: Arial, sans-serif;
+  max-width: 600px;
+  margin: 20px auto;
+}
+
+#balance {
+  font-size: 2em;
+}
+
+#send-form {
+  margin: 20px 0;
+  display: flex;
+  gap: 10px;
+}
+
+#send-form input {
+  flex: 1;
+  padding: 5px;
+}
+
+#send-form button {
+  padding: 5px 10px;
+}
+
+#history {
+  border-top: 1px solid #ddd;
+  margin-top: 20px;
+}
+
+#history .tx-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 0;
+  border-bottom: 1px solid #eee;
+}
+
+#history .positive {
+  color: green;
+}
+
+#history .negative {
+  color: red;
+}


### PR DESCRIPTION
## Summary
- add minimal wallet interface script showing balance, transaction history and send form
- style wallet elements with SCSS
- update HTML page to include wallet markup and resources

## Testing
- `npm install` *(fails: node-sass build error)*
- `npm run build-renderer` *(fails: requires interactive npx download)*

------
https://chatgpt.com/codex/tasks/task_e_68591502f1948324ac5b3af10f75947f