### PR TITLE
Add IPC-based BlocXus module

### DIFF
--- a/src/main/blocxus.js
+++ b/src/main/blocxus.js
@@ -1,0 +1,24 @@
+const crypto = require('crypto');
+
+const balances = new Map();
+
+function generateAddress() {
+  // Simple pseudo address generation using random bytes
+  return crypto.randomBytes(20).toString('hex');
+}
+
+function getBalance(address) {
+  return balances.get(address) || 0;
+}
+
+function sendTransaction({ from, to, amount }) {
+  const fromBalance = getBalance(from);
+  if (fromBalance < amount) {
+    throw new Error('Insufficient funds');
+  }
+  balances.set(from, fromBalance - amount);
+  balances.set(to, getBalance(to) + amount);
+  return { hash: crypto.randomBytes(32).toString('hex') };
+}
+
+module.exports = { generateAddress, getBalance, sendTransaction };

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,14 +1,32 @@
-const {app, BrowserWindow} = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 const url = require('url');
+const blocxus = require('./blocxus');
 
 // Храните глобальную ссылку на объект окна, если вы этого не сделаете, окно будет
 // автоматически закрываться, когда объект JavaScript собирает мусор.
 let win;
 
+ipcMain.handle('generate-address', () => blocxus.generateAddress());
+ipcMain.handle('get-balance', (event, address) => blocxus.getBalance(address));
+ipcMain.handle('send-transaction', (event, tx) => {
+    try {
+        return blocxus.sendTransaction(tx);
+    } catch (e) {
+        return { error: e.message };
+    }
+});
+
 function createWindow () {
     // Создаёт окно браузера.
-    win = new BrowserWindow({width: 800, height: 600});
+    win = new BrowserWindow({
+        width: 800,
+        height: 600,
+        webPreferences: {
+            nodeIntegration: true,
+            contextIsolation: false
+        }
+    });
 
     // и загрузит index.html приложение.
     win.loadURL(url.format({

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -7,5 +7,10 @@
             Hello EdenCoin
         </div>
         <script src="js/script.js"></script>
+        <script>
+            window.blocxus.generateAddress().then(addr => {
+                console.log('Generated address:', addr);
+            });
+        </script>
     </body>
 </html>

--- a/src/renderer/js/script.js
+++ b/src/renderer/js/script.js
@@ -1,0 +1,7 @@
+const { ipcRenderer } = require('electron');
+
+window.blocxus = {
+  generateAddress: () => ipcRenderer.invoke('generate-address'),
+  getBalance: (address) => ipcRenderer.invoke('get-balance', address),
+  sendTransaction: (tx) => ipcRenderer.invoke('send-transaction', tx)
+};


### PR DESCRIPTION
## Summary
- add BlocXus blockchain helper
- wire IPC handlers in Electron main process
- expose IPC helpers in renderer
- demo address generation in the HTML page

## Testing
- `npm run build-main` *(fails: Need to install the following packages: babel@5.8.38)*
